### PR TITLE
Bugfix/remove pwa category

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-performance-plugin",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "package.json",
   "license": "UNLICENSED",
   "type": "module",

--- a/plugins/sanity-lighthouse/package.config.ts
+++ b/plugins/sanity-lighthouse/package.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from '@sanity/pkg-utils'
+import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
   legacyExports: true,
   dist: 'dist',
   tsconfig: 'tsconfig.dist.json',
-  external: ["styled-components", "@sanity/ui"],
+  external: ['styled-components', '@sanity/ui'],
 
   // Remove this block to enable strict export validation
   extract: {

--- a/plugins/sanity-lighthouse/src/components/RenderCategories.tsx
+++ b/plugins/sanity-lighthouse/src/components/RenderCategories.tsx
@@ -22,9 +22,11 @@ const Title = styled.h3`
 const RenderCategories = ({item}) => {
   const {score, title} = item
 
+  const validScore = isNaN(score) || score === undefined ? 0 : score
+
   return (
     <PieContainer>
-      <PieChartComponent title={title} score={score} />
+      <PieChartComponent title={title} score={validScore} />
       <Title>{title}</Title>
     </PieContainer>
   )

--- a/plugins/sanity-lighthouse/src/components/module.d.ts
+++ b/plugins/sanity-lighthouse/src/components/module.d.ts
@@ -1,1 +1,1 @@
-declare module '*';
+declare module '*'

--- a/plugins/sanity-lighthouse/src/helpers/apiRequest.js
+++ b/plugins/sanity-lighthouse/src/helpers/apiRequest.js
@@ -6,9 +6,7 @@ const endpoint = 'https://pagespeedonline.googleapis.com/pagespeedonline/v5/runP
 
 export const apiRequestByDeviceAllCategories = async (url, device = 'desktop', API_KEY) => {
   const req = CATEGORIES.map((category) => {
-    return axios(
-      `${endpoint}?url=${url}&strategy=${device}&key=${API_KEY}&category=${category}`
-    )
+    return axios(`${endpoint}?url=${url}&strategy=${device}&key=${API_KEY}&category=${category}`)
   })
   return Promise.all(req)
 }

--- a/plugins/sanity-lighthouse/src/helpers/constants.js
+++ b/plugins/sanity-lighthouse/src/helpers/constants.js
@@ -4,14 +4,14 @@ export const SECRETS_PLUGIN_CONFIG_KEYS = [
   {
     key: 'apiKey',
     title: 'Your secret API key',
-  }
+  },
 ]
 
 export const STATE_TYPE = {idle: 'idle', loading: 'loading', success: 'success', error: 'error'}
 
-export const CATEGORIES = ['PERFORMANCE', 'PWA', 'SEO', 'BEST_PRACTICES', 'ACCESSIBILITY']
+export const CATEGORIES = ['PERFORMANCE', 'SEO', 'BEST_PRACTICES', 'ACCESSIBILITY']
 
-export const CATEGORIES_TITLE = ['Performance', 'PWA', 'SEO', 'Best Practices', 'Accessibility']
+export const CATEGORIES_TITLE = ['Performance', 'SEO', 'Best Practices', 'Accessibility']
 export const LIST_DEVICES = {mobile: 'mobile', desktop: 'desktop'}
 
 export const COLORS = ['#5CC971', '#F3AE4E', '#EB483F']

--- a/plugins/sanity-lighthouse/tsconfig.settings.json
+++ b/plugins/sanity-lighthouse/tsconfig.settings.json
@@ -11,6 +11,6 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "noImplicitAny": false,
-  },
+    "noImplicitAny": false
+  }
 }


### PR DESCRIPTION
## Remove PWA Category and Adjust Metrics Formatting in Lighthouse Plugin
- Removed the "PWA" category from both the `CATEGORIES` and `CATEGORIES_TITLE` constants.
- Updated the formatMetrics function to handle the absence of the "PWA" category gracefully.
- Added validation to check if the categories or audits data is invalid. The system now logs an error message when such data is encountered and defaults to empty arrays for mobile and desktop results.
